### PR TITLE
fix: 修复 [bug] 影子重写偶有操作失误时无法回退，关闭代码重写导致reload window

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -12,6 +12,7 @@
   "No code available for Shadow Rewriting.": "No code available for Shadow Rewriting.",
   "Shadow Rewriting started. Press Esc to exit.": "Shadow Rewriting started. Press Esc to exit.",
   "Shadow Rewriting stopped.": "Shadow Rewriting stopped.",
+  "Shadow Rewriting stopped, cause by user moved input cursor. can be manual restart.": "Shadow Rewriting stopped, cause by user moved input cursor. can be manual restart.",
   "Code rewriting is not active, so it cannot be paused.": "Code rewriting is not active, so it cannot be paused.",
   "Switched to {0} mode.": "Switched to {0} mode.",
   "No closed Look While Typing target to reopen.": "No closed Look While Typing target to reopen.",

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -12,6 +12,7 @@
   "No code available for Shadow Rewriting.": "没有可用于影子重写的代码。",
   "Shadow Rewriting started. Press Esc to exit.": "影子重写已开始。按 Esc 退出。",
   "Shadow Rewriting stopped.": "影子重写已停止。",
+  "Shadow Rewriting stopped, cause by user moved input cursor. can be manual restart.": "因光标被移动，影子重写已停止，可手动重新开始。",
   "Code rewriting is not active, so it cannot be paused.": "代码重写尚未启动，无法暂停。",
   "Switched to {0} mode.": "已切换到 {0} 模式。",
   "No closed Look While Typing target to reopen.": "没有可重新打开的边打边看工作编辑器。",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import {
     TextEditor,
     TextEditorEdit,
     TextEditorRevealType,
+    TextEditorSelectionChangeKind,
     TextDocument,
     Uri,
     window,
@@ -29,6 +30,8 @@ import {
     isShadowPrefixAligned as isTargetPrefixAligned,
     KeyedAsyncQueue,
     shouldAbandonShadowSession,
+    shouldAbandonShadowSessionAfterSelectionChange,
+    shouldContinueRewrite,
 } from './shadowInline';
 import {
     getLookWhileTypingAction,
@@ -43,6 +46,7 @@ import {
 const TYPE_COMMAND = 'type';
 const DEFAULT_TYPE_COMMAND = 'default:type';
 const DEFAULT_DELETE_LEFT_COMMAND = 'deleteLeft';
+const DEFAULT_TAB_COMMAND = 'tab';
 const SHADOW_CONTEXT = 'vscodePluginSwimming.shadowActive';
 const SHADOW_DELETE_LEFT_COMMAND = 'extension.swimming.shadowDeleteLeft';
 const SHADOW_ENTER_COMMAND = 'extension.swimming.shadowEnter';
@@ -639,6 +643,31 @@ function clearAllShadowSessions() {
     refreshInlineSuggestion();
 }
 
+function handleShadowSelectionChange(
+    textEditor: TextEditor,
+    selections: readonly Selection[],
+    isUserNavigation: boolean
+) {
+    const editorKey = getEditorKey(textEditor);
+    const shadowSession = shadowSessionMap.get(editorKey);
+    if (!shadowSession) {
+        return;
+    }
+
+    const cursors = selections.map(({ active }) => ({
+        line: active.line,
+        character: active.character,
+    }));
+    if (shouldAbandonShadowSessionAfterSelectionChange(
+        shadowSession,
+        cursors,
+        isUserNavigation
+    )) {
+        clearShadowSession(editorKey);
+         window.showInformationMessage(l10n.t('Shadow Rewriting stopped, cause by user moved input cursor. can be manual restart.'));
+    }
+}
+
 function showPauseinfo(textEditor: TextEditor) {
     if (isWriteCodePauseMap.get(getEditorKey(textEditor))) {
         window.showInformationMessage(l10n.t('Code rewriting is paused.'));
@@ -1012,16 +1041,19 @@ function rewriteCodeWithStartAndEnd({
 
     const runWrite = function() {
         const inputTimeout: NodeJS.Timeout = setTimeout(() => {
+            if (!shouldContinueRewrite(
+                isWritingCodeMap.get(editorKey),
+                textEditor.document.isClosed
+            )) {
+                return recycleWrite(inputTimeout);
+            }
+
             if (isWriteCodePauseMap.get(editorKey)) {
                 return textEditor.edit(() => undefined)
                     .then(() => runWrite(), (reason) => {
                         recycleWrite(inputTimeout);
                         throw new Error(String(reason));
                     });
-            }
-
-            if (textEditor.document.isClosed) {
-                return recycleWrite(inputTimeout);
             }
 
             if (session.index >= session.beforeText.length) {
@@ -1118,7 +1150,6 @@ function closeWriteCode(
     clearAllShadowSessions();
     isWriteCodePauseMap.clear();
     isWritingCodeMap.clear();
-    commands.executeCommand('workbench.action.reloadWindow');
 }
 
 function pauseWriteCode(
@@ -1261,12 +1292,17 @@ async function handleShadowEnter() {
     const editorKey = getEditorKey(textEditor);
     const shadowSession = shadowSessionMap.get(editorKey);
     if (!shadowSession) {
-        return;
+        return commands.executeCommand(DEFAULT_TYPE_COMMAND, { text: '\n' });
     }
 
     return shadowInputQueue.enqueue(editorKey, async () => {
         if (shadowSessionMap.get(editorKey) !== shadowSession) {
-            return;
+            return commands.executeCommand(DEFAULT_TYPE_COMMAND, { text: '\n' });
+        }
+
+        if (!canAdvanceShadowSession(textEditor, shadowSession)) {
+            clearShadowSession(editorKey);
+            return commands.executeCommand(DEFAULT_TYPE_COMMAND, { text: '\n' });
         }
 
         if (!getShadowRequireManualLineBreaksAndIndentation()) {
@@ -1289,12 +1325,17 @@ async function handleShadowTab() {
     const editorKey = getEditorKey(textEditor);
     const shadowSession = shadowSessionMap.get(editorKey);
     if (!shadowSession) {
-        return;
+        return commands.executeCommand(DEFAULT_TAB_COMMAND);
     }
 
     return shadowInputQueue.enqueue(editorKey, async () => {
         if (shadowSessionMap.get(editorKey) !== shadowSession) {
-            return;
+            return commands.executeCommand(DEFAULT_TAB_COMMAND);
+        }
+
+        if (!canAdvanceShadowSession(textEditor, shadowSession)) {
+            clearShadowSession(editorKey);
+            return commands.executeCommand(DEFAULT_TAB_COMMAND);
         }
 
         if (!getShadowRequireManualLineBreaksAndIndentation()) {
@@ -1396,6 +1437,14 @@ export function activate(context: ExtensionContext) {
     context.subscriptions.push(
         registerShadowInlineCompletionProvider(),
         window.onDidChangeVisibleTextEditors(updateLookWhileTypingContext),
+        window.onDidChangeTextEditorSelection(({ textEditor, selections, kind }) => {
+            handleShadowSelectionChange(
+                textEditor,
+                selections,
+                kind === TextEditorSelectionChangeKind.Keyboard
+                    || kind === TextEditorSelectionChangeKind.Mouse
+            );
+        }),
         workspace.onDidRenameFiles(({ files }) => {
             void updateLookWhileTypingTargetAfterWorkspaceRename(context, files);
         }),

--- a/src/shadowInline.ts
+++ b/src/shadowInline.ts
@@ -109,6 +109,30 @@ export function shouldAbandonShadowSession(
         && (actualPrefix !== expectedPrefix || !cursorAtSessionPosition);
 }
 
+export function shouldAbandonShadowSessionAfterSelectionChange(
+    session: ShadowInlineSession,
+    cursors: readonly ShadowCursor[],
+    isUserNavigation = false
+) {
+    if (!isUserNavigation) {
+        return false;
+    }
+
+    if (cursors.length !== 1) {
+        return true;
+    }
+
+    return cursors[0].line !== session.line
+        || cursors[0].character !== session.character;
+}
+
+export function shouldContinueRewrite(
+    isWriting: boolean | undefined,
+    documentIsClosed: boolean
+) {
+    return isWriting === true && !documentIsClosed;
+}
+
 export function canUseGenericShadowTyping(
     policy: ShadowGenericTypingPolicy
 ) {

--- a/test/issue14.test.js
+++ b/test/issue14.test.js
@@ -1,0 +1,66 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+    shouldAbandonShadowSessionAfterSelectionChange,
+    shouldContinueRewrite,
+} = require('../out/shadowInline');
+
+test('abandons Shadow Rewriting when the cursor leaves the session position', () => {
+    const session = {
+        beforeText: 'target',
+        index: 2,
+        line: 4,
+        character: 7,
+    };
+
+    assert.equal(
+        shouldAbandonShadowSessionAfterSelectionChange(session, [{ line: 4, character: 7 }]),
+        false
+    );
+    assert.equal(
+        shouldAbandonShadowSessionAfterSelectionChange(
+            session,
+            [{ line: 4, character: 8 }],
+            true
+        ),
+        true
+    );
+    assert.equal(
+        shouldAbandonShadowSessionAfterSelectionChange(session, [
+            { line: 4, character: 7 },
+            { line: 5, character: 0 },
+        ], true),
+        true
+    );
+    assert.equal(
+        shouldAbandonShadowSessionAfterSelectionChange(
+            session,
+            [{ line: 4, character: 8 }],
+            false
+        ),
+        false
+    );
+});
+
+test('stops scheduled rewriting after the active state is cleared', () => {
+    assert.equal(shouldContinueRewrite(true, false), true);
+    assert.equal(shouldContinueRewrite(false, false), false);
+    assert.equal(shouldContinueRewrite(undefined, false), false);
+    assert.equal(shouldContinueRewrite(true, true), false);
+});
+
+test('closes code rewriting without reloading the VS Code window', () => {
+    const extensionSource = fs.readFileSync(
+        path.resolve(__dirname, '..', 'src', 'extension.ts'),
+        'utf8'
+    );
+    const closeFunction = extensionSource.match(
+        /function closeWriteCode[\s\S]*?\n}\n\nfunction pauseWriteCode/
+    );
+
+    assert.ok(closeFunction, 'closeWriteCode implementation was not found');
+    assert.doesNotMatch(closeFunction[0], /reloadWindow/);
+});


### PR DESCRIPTION
修复 #14 提出的问题

具体修复措施为一旦用户移动光标，影子重写模式将立刻停止。
代码重写导致的reload window问题系关闭重写后定时循环仍在计时，导致vsc reload。